### PR TITLE
Handles initializing CjObject using keys with spaces

### DIFF
--- a/lib/commission_junction.rb
+++ b/lib/commission_junction.rb
@@ -178,9 +178,14 @@ class CommissionJunction
       # Credit:  http://listlibrary.net/ruby-talk/2004/03/00sGI1cD
       params.each do |key, val|
         raise ArgumentError, "key must be a String; got #{key.class} instead" unless key.is_a?(String)
-        instance_variable_set("@#{key}".intern, val)
-        instance_eval %Q{ class << self ; attr_reader #{key.intern.inspect} ; end }
+        clean_key = clean_key_name(key)
+        instance_variable_set("@#{clean_key}".intern, val)
+        instance_eval %Q{ class << self ; attr_reader #{clean_key.intern.inspect} ; end }
       end
+    end
+
+    def clean_key_name(name)
+      name.strip.gsub(/\s/, '_')
     end
   end
 

--- a/test/commission_junction_test.rb
+++ b/test/commission_junction_test.rb
@@ -389,11 +389,15 @@ class CommissionJunctionTest < Minitest::Test
     end
   end
 
+  def set_up_service
+    CommissionJunction.new('developer_key', 123456)
+  end
+
   def test_contents_extractor_with_first_level
     contents = "abc"
     response = {'cj_api' => {'first' => contents}}
 
-    cj = CommissionJunction.new('developer_key', 123456)
+    cj = set_up_service
 
     assert_equal(contents, cj.extract_contents(response, "first"))
   end
@@ -402,7 +406,7 @@ class CommissionJunctionTest < Minitest::Test
     contents = "abc"
     response = {'cj_api' => {'first' => {'second' => contents}}}
 
-    cj = CommissionJunction.new('developer_key', 123456)
+    cj = set_up_service
 
     assert_equal(contents, cj.extract_contents(response, "first", "second"))
   end
@@ -411,7 +415,7 @@ class CommissionJunctionTest < Minitest::Test
     contents = "abc"
     response = {'cj_api' => {'error_message' => contents}}
 
-    cj = CommissionJunction.new('developer_key', 123456)
+    cj = set_up_service
 
     assert_raises ArgumentError do
       cj.extract_contents(response, "first")
@@ -421,10 +425,31 @@ class CommissionJunctionTest < Minitest::Test
   def test_contents_extractor_with_no_cj_api
     response = {}
 
-    cj = CommissionJunction.new('developer_key', 123456)
+    cj = set_up_service
 
     assert_raises ArgumentError do
       cj.extract_contents(response, "first")
     end
+  end
+
+  def set_up_cj_object
+    CommissionJunction::CjObject.new({"a" => "a"})
+  end
+
+  def test_key_conversion_with_spaces
+    cjo = set_up_cj_object
+
+    assert_equal("abc_def", cjo.clean_key_name("abc def"))
+  end
+
+  def test_key_conversion_with_trailing_spaces
+    cjo = set_up_cj_object
+
+    assert_equal("abcdef", cjo.clean_key_name("abcdef "))
+  end
+
+  def test_initializing_product_using_key_with_spaces
+    product = CommissionJunction::Product.new("abc def" => "123")
+    assert_equal(product.abc_def, "123")
   end
 end


### PR DESCRIPTION
We have been getting data from Commission Junction with keys that have spaces in them. This fix allows the gem to support those keys.