### PR TITLE
Fix deprecated Fixnum constant (ruby 2.5.0)

### DIFF
--- a/commission_junction.gemspec
+++ b/commission_junction.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
   gem.add_dependency 'httparty', '~> 0.13'
-  gem.add_development_dependency 'minitest', '~> 0'
+  gem.add_development_dependency 'minitest', '> 0'
   gem.add_dependency 'ox', '~> 2.1'
   gem.license = 'BSD-3-Clause'
 end

--- a/lib/commission_junction.rb
+++ b/lib/commission_junction.rb
@@ -33,7 +33,7 @@ class CommissionJunction
     raise ArgumentError, "You must supply your website ID.\nSee cj.com > Account > Web site Settings > PID" if website_id.empty?
     @website_id = website_id
 
-    raise ArgumentError, "timeout must be a Fixnum; got #{timeout.class} instead" unless timeout.is_a?(Fixnum)
+    raise ArgumentError, "timeout must be a Integer; got #{timeout.class} instead" unless timeout.is_a?(Integer)
     raise ArgumentError, "timeout must be > 0; got #{timeout} instead" unless timeout > 0
     @timeout = timeout
 

--- a/test/commission_junction_test.rb
+++ b/test/commission_junction_test.rb
@@ -189,9 +189,9 @@ class CommissionJunctionTest < Minitest::Test
   end
 
   def check_search_results(results)
-    assert_instance_of(Fixnum, results.total_matched)
-    assert_instance_of(Fixnum, results.records_returned)
-    assert_instance_of(Fixnum, results.page_number)
+    assert_instance_of(Integer, results.total_matched)
+    assert_instance_of(Integer, results.records_returned)
+    assert_instance_of(Integer, results.page_number)
     assert_instance_of(Array, results.cj_objects)
 
     results.cj_objects.each do |product|
@@ -256,9 +256,9 @@ class CommissionJunctionTest < Minitest::Test
   end
 
   def check_advertiser_lookup_results(results)
-    assert_instance_of(Fixnum, results.total_matched)
-    assert_instance_of(Fixnum, results.records_returned)
-    assert_instance_of(Fixnum, results.page_number)
+    assert_instance_of(Integer, results.total_matched)
+    assert_instance_of(Integer, results.records_returned)
+    assert_instance_of(Integer, results.page_number)
     assert_instance_of(Array, results.cj_objects)
 
     results.cj_objects.each do |advertiser|
@@ -308,9 +308,9 @@ class CommissionJunctionTest < Minitest::Test
   end
 
   def check_commission_lookup_results(results)
-    assert_instance_of(Fixnum, results.total_matched)
-    assert_instance_of(Fixnum, results.records_returned)
-    assert_instance_of(Fixnum, results.page_number)
+    assert_instance_of(Integer, results.total_matched)
+    assert_instance_of(Integer, results.records_returned)
+    assert_instance_of(Integer, results.page_number)
     assert_instance_of(Array, results.cj_objects)
 
     results.cj_objects.each do |commission|
@@ -427,9 +427,9 @@ class CommissionJunctionTest < Minitest::Test
   end
 
   def check_link_search_results(results)
-    assert_instance_of(Fixnum, results.total_matched)
-    assert_instance_of(Fixnum, results.records_returned)
-    assert_instance_of(Fixnum, results.page_number)
+    assert_instance_of(Integer, results.total_matched)
+    assert_instance_of(Integer, results.records_returned)
+    assert_instance_of(Integer, results.page_number)
     assert_instance_of(Array, results.cj_objects)
 
     results.cj_objects.each do |link|


### PR DESCRIPTION
Looks like those changes are backwards compatible.